### PR TITLE
server: use getters with read lock to prevent races (#16)

### DIFF
--- a/server_tcp_test.go
+++ b/server_tcp_test.go
@@ -50,9 +50,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 	}
 
 	// the server should have zero client connections so far
-	if len(server.tcpClients) != 0 {
+	if server.ClientsNumber() != 0 {
 		t.Errorf("expected server.tcpClients to hold 0 entries, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// connect client #1
@@ -64,9 +64,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 
 	// the server should have 1 client connection at this point
 	time.Sleep(time.Millisecond)
-	if len(server.tcpClients) != 1 {
+	if server.ClientsNumber() != 1 {
 		t.Errorf("expected server.tcpClients to hold 1 entry, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// connect client #2
@@ -78,9 +78,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 
 	time.Sleep(time.Millisecond)
 	// the server should now have 2 client connections, its maximum allowed
-	if len(server.tcpClients) != 2 {
+	if server.ClientsNumber() != 2 {
 		t.Errorf("expected server.tcpClients to hold 2 entries, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// connect client #3
@@ -92,9 +92,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 
 	// since the previous client was rejected, the active connection count
 	// should stay at 2
-	if len(server.tcpClients) != 2 {
+	if server.ClientsNumber() != 2 {
 		t.Errorf("expected server.tcpClients to hold 2 entries, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// c1 and c2 should both be able to make requests while c3 should error out
@@ -123,9 +123,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 	// close c2 and make sure the connection is freed
 	c2.Close()
 	time.Sleep(time.Millisecond)
-	if len(server.tcpClients) != 1 {
+	if server.ClientsNumber() != 1 {
 		t.Errorf("expected server.tcpClients to hold 1 entry, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// reconnect c2
@@ -140,9 +140,9 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 		t.Errorf("c2.WriteCoil() should have succeeded, got: %v", err)
 	}
 
-	if len(server.tcpClients) != 2 {
+	if server.ClientsNumber() != 2 {
 		t.Errorf("expected server.tcpClients to hold 2 entries, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// check the coil value with c1
@@ -157,18 +157,18 @@ func TestTCPServerWithConcurrentConnections(t *testing.T) {
 	// close c1 and make sure the connection is freed
 	c1.Close()
 	time.Sleep(time.Millisecond)
-	if len(server.tcpClients) != 1 {
+	if server.ClientsNumber() != 1 {
 		t.Errorf("expected server.tcpClients to hold 1 entry, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// stopping the server should disconnect all clients
 	server.Stop()
 
 	time.Sleep(time.Millisecond)
-	if len(server.tcpClients) != 0 {
+	if server.ClientsNumber() != 0 {
 		t.Errorf("expected server.tcpClients to hold 0 entries, got: %v",
-			 len(server.tcpClients))
+			 server.ClientsNumber())
 	}
 
 	// c2 should have been disconnected

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -302,8 +302,8 @@ func TestTLSServer(t *testing.T) {
 
 	// make sure all underlying TCP client connections have been freed
 	time.Sleep(10 * time.Millisecond)
-	if len(server.tcpClients) != 0 {
-		t.Errorf("expected 0 client connections, saw: %v", len(server.tcpClients))
+	if server.ClientsNumber() != 0 {
+		t.Errorf("expected 0 client connections, saw: %v", server.ClientsNumber())
 	}
 
 	// cleanup


### PR DESCRIPTION
Hi @simonvetter, following #16 here is a proposal that make use of _read locks_ to prevent races

Feel free to ask for adjustments if needed !