### PR TITLE
[Fix]: Add nil check in client.Close

### DIFF
--- a/client.go
+++ b/client.go
@@ -321,8 +321,10 @@ func (mc *ModbusClient) Open() (err error) {
 func (mc *ModbusClient) Close() (err error) {
 	mc.lock.Lock()
 	defer mc.lock.Unlock()
-
-	err = mc.transport.Close()
+	
+	if mc.transport != nil {
+		err = mc.transport.Close()
+	}
 
 	return
 }


### PR DESCRIPTION
This PR checks if the `transport` is not nil before closing it in `client.Close()`. This avoid panics.