### PR TITLE
fix: panic when transport is not initialized

### DIFF
--- a/client.go
+++ b/client.go
@@ -1184,6 +1184,10 @@ func (mc *ModbusClient) writeRegisters(addr uint16, values []byte) (err error) {
 }
 
 func (mc *ModbusClient) executeRequest(req *pdu) (res *pdu, err error) {
+  if mc.transport == nil {
+    err = ErrTransportNotInitialized
+    return
+  }
 	// send the request over the wire, wait for and decode the response
 	res, err	= mc.transport.ExecuteRequest(req)
 	if err != nil {

--- a/modbus.go
+++ b/modbus.go
@@ -70,6 +70,7 @@ const (
 	ErrBadTransactionId          Error = "bad transaction id"
 	ErrUnknownProtocolId         Error = "unknown protocol identifier"
 	ErrUnexpectedParameters      Error = "unexpected parameters"
+	ErrTransportNotInitialized   Error = "Transport is not initialized"
 )
 
 // mapExceptionCodeToError turns a modbus exception code into a higher level Error object.

--- a/modbus.go
+++ b/modbus.go
@@ -70,7 +70,7 @@ const (
 	ErrBadTransactionId          Error = "bad transaction id"
 	ErrUnknownProtocolId         Error = "unknown protocol identifier"
 	ErrUnexpectedParameters      Error = "unexpected parameters"
-	ErrTransportNotInitialized   Error = "Transport is not initialized"
+	ErrTransportNotInitialized   Error = "transport is not initialized"
 )
 
 // mapExceptionCodeToError turns a modbus exception code into a higher level Error object.


### PR DESCRIPTION
This PR resolves a runtime panic that occurs when the Modbus transport fails to initialize. Previously, if the transport was not successfully created, attempting to read the registers would lead to a runtime panic. This fix ensures that the code checks for a valid transport before proceeding with register reads, preventing the panic and providing a error message instead.


How to reproduce

```golang 
package main

import (
	"time"

	"github.com/simonvetter/modbus"
)

func main() {
	modbusClient, err := modbus.NewClient(&modbus.ClientConfiguration{
		URL:     "tcp://192.168.2.2:502", // Some fake URL 
		Timeout: time.Second,
	})

	if err = modbusClient.Open(); err != nil {
		println(err.Error())
	}

	if _, err = modbusClient.ReadRegister(100, modbus.HOLDING_REGISTER); err != nil {
		println(err.Error())
	}
}

```

Output without the fix: 

```
dial tcp 192.168.2.2:502: i/o timeout
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x1022d2064]
```

Output with the fix:
```
dial tcp 192.168.2.2:502: i/o timeout
Transport is not initialized
```