### PR TITLE
fix: reconnect for connection resets

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-    ErrConnectionClosed = errors.New("connection closed by peer")
+	ErrConnectionClosed = errors.New("connection closed by peer")
 )
 
 // Modbus client configuration object.
@@ -66,8 +66,8 @@ type ClientConfiguration struct {
 
 
 type connState struct {
-    transport transport
-    closed    atomic.Bool
+	transport transport
+	closed    atomic.Bool
 }
 
 // Modbus client object.
@@ -210,12 +210,12 @@ func NewClient(conf *ClientConfiguration) (mc *ModbusClient, err error) {
 
 
 func (mc *ModbusClient) createTransport() (transport, error) {
-    var spw *serialPortWrapper
-    var sock net.Conn
-    var err error
+	var spw *serialPortWrapper
+	var sock net.Conn
+	var err error
 
-    switch mc.transportType {
- 	case modbusRTU:
+	switch mc.transportType {
+		case modbusRTU:
 		// create a serial port wrapper object
 		spw = newSerialPortWrapper(&serialPortConfig{
 			Device:		mc.conf.URL,
@@ -330,38 +330,38 @@ func (mc *ModbusClient) createTransport() (transport, error) {
 // Opens the underlying transport (network socket or serial line).
 func (mc *ModbusClient) Open() (err error) {
 	transport, err := mc.createTransport()
-    if err != nil {
-        return err
-    }
+	if err != nil {
+	return err
+	}
 
-    conn := &connState{
-        transport: transport,
-    }
-    mc.conn.Store(conn)
-    return nil
+	conn := &connState{
+	transport: transport,
+	}
+	mc.conn.Store(conn)
+	return nil
 }
 
 
 func (mc *ModbusClient) Reconnect() error {
-    newTransport, err := mc.createTransport()
-    if err != nil {
-        return fmt.Errorf("failed to create new transport: %w", err)
-    }
+	newTransport, err := mc.createTransport()
+	if err != nil {
+	return fmt.Errorf("failed to create new transport: %w", err)
+	}
 
-    // Get current connection state
-    oldConn := mc.conn.Load()
-    if oldConn != nil {
-        oldConn.transport.Close()
-        oldConn.closed.Store(true)
-    }
+	// Get current connection state
+	oldConn := mc.conn.Load()
+	if oldConn != nil {
+	oldConn.transport.Close()
+	oldConn.closed.Store(true)
+	}
 
-    // Store new connection
-    newConn := &connState{
-        transport: newTransport,
-    }
-    mc.conn.Store(newConn)
-    
-    return nil
+	// Store new connection
+	newConn := &connState{
+	transport: newTransport,
+	}
+	mc.conn.Store(newConn)
+	
+	return nil
 }
 
 // Closes the underlying transport.
@@ -1244,18 +1244,18 @@ func (mc *ModbusClient) executeRequest(req *pdu) (res *pdu, err error) {
 	res, err	= conn.transport.ExecuteRequest(req)
 
 	// If connection was closed, try one reconnection attempt
-    if err == ErrConnectionClosed {
-        mc.logger.Warning("Connection closed, attempting reconnection...")
-        if rerr := mc.Reconnect(); rerr != nil {
-            return nil, fmt.Errorf("reconnection failed: %w", rerr)
-        }
-        // Retry the request after successful reconnection
+	if err == ErrConnectionClosed {
+	mc.logger.Warning("Connection closed, attempting reconnection...")
+	if rerr := mc.Reconnect(); rerr != nil {
+	return nil, fmt.Errorf("reconnection failed: %w", rerr)
+	}
+	// Retry the request after successful reconnection
 		conn = mc.conn.Load()
 		if conn == nil {
 			return nil, ErrConnectionClosed
 		}
-        res, err = conn.transport.ExecuteRequest(req)
-    }
+	res, err = conn.transport.ExecuteRequest(req)
+	}
 
 	if err != nil {
 		// map i/o timeouts to ErrRequestTimedOut

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/simonvetter/modbus
 
-go 1.16
+go 1.18
 
 require github.com/goburrow/serial v0.1.0

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -135,9 +135,9 @@ func (tt *tcpTransport) readMBAPFrame() (p *pdu, txnId uint16, err error) {
 	_, err		= io.ReadFull(tt.socket, rxbuf)
 	if err != nil {
 		if err == io.EOF {
-            tt.socket.Close()
-            err = ErrConnectionClosed
-        }
+			tt.socket.Close()
+			err = ErrConnectionClosed
+		}
 		return
 	}
 
@@ -171,9 +171,9 @@ func (tt *tcpTransport) readMBAPFrame() (p *pdu, txnId uint16, err error) {
 	_, err		= io.ReadFull(tt.socket, rxbuf)
 	if err != nil {
 		if err == io.EOF {
-            tt.socket.Close()
-            err = ErrConnectionClosed
-        }
+			tt.socket.Close()
+			err = ErrConnectionClosed
+		}
 		return
 	}
 

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -134,6 +134,10 @@ func (tt *tcpTransport) readMBAPFrame() (p *pdu, txnId uint16, err error) {
 	rxbuf		= make([]byte, mbapHeaderLength)
 	_, err		= io.ReadFull(tt.socket, rxbuf)
 	if err != nil {
+		if err == io.EOF {
+            tt.socket.Close()
+            err = ErrConnectionClosed
+        }
 		return
 	}
 
@@ -166,6 +170,10 @@ func (tt *tcpTransport) readMBAPFrame() (p *pdu, txnId uint16, err error) {
 	rxbuf		= make([]byte, bytesNeeded)
 	_, err		= io.ReadFull(tt.socket, rxbuf)
 	if err != nil {
+		if err == io.EOF {
+            tt.socket.Close()
+            err = ErrConnectionClosed
+        }
 		return
 	}
 


### PR DESCRIPTION
This PR fixes the issue of using stale connection when the slave is restarted.

##### How to reproduce

```go
package main

import (
	"log"
	"time"

	"github.com/simonvetter/modbus"
)

func main() {
	client, err := modbus.NewClient(&modbus.ClientConfiguration{
		URL:     "tcp://localhost:5555",
		Timeout: 1 * time.Second,
	})

	if err != nil {
		log.Fatalf("Failed to create Modbus client: %v", err)
	}

	if err = client.Open(); err != nil {
		log.Fatalf("Failed to open Modbus client: %v", err)
	}
	defer client.Close()

	for range 10 {
		read(client)
		time.Sleep(2 * time.Second)
	}

}

func read(client *modbus.ModbusClient) {
	reg16, err := client.ReadRegister(100, modbus.HOLDING_REGISTER)
	if err != nil {
		log.Printf("Failed to read register: %v", err)
	} else {
		// use value
		log.Printf("Read register value: %v", reg16)
	}
}
```

While the master is polling restart the slave.

```
2025/04/10 01:11:46 Read register value: 0
2025/04/10 01:11:48 Failed to read register: EOF
2025/04/10 01:11:50 Failed to read register: write tcp 127.0.0.1:47154->127.0.0.1:5555: write: broken pipe
```

Please note that I am wrapping the transport in atomic value as I was not able to easily resolve the deadlock issue that would arise with reconnecting while the lock was already acquired by the command.

Also updated minimum supported go version to 1.18 for the generic support of the struct.